### PR TITLE
chore: update workload.yaml to use HTTP endpoint type

### DIFF
--- a/service-ballerina-patient-management/workload.yaml
+++ b/service-ballerina-patient-management/workload.yaml
@@ -21,9 +21,9 @@ endpoints:
     # +required Numeric port value that gets exposed via the endpoint
     port: 9090
     # +required Type of traffic that the endpoint is accepting
-    # Allowed values: REST, GraphQL, gRPC, TCP, UDP, HTTP, Websocket
-    type: REST
+    # Allowed values: GraphQL, gRPC, TCP, UDP, HTTP, Websocket
+    type: HTTP
     # +optional The path to the schema definition file
-    # This is applicable to REST, GraphQL, and gRPC endpoint types
+    # This is applicable to HTTP, GraphQL, and gRPC endpoint types
     # The path should be relative to the workload.yaml file location
     schemaFile: openapi.yaml

--- a/service-go-greeter/workload.yaml
+++ b/service-go-greeter/workload.yaml
@@ -21,9 +21,9 @@ endpoints:
     # +required Numeric port value that gets exposed via the endpoint
     port: 9090
     # +required Type of traffic that the endpoint is accepting
-    # Allowed values: REST, GraphQL, gRPC, TCP, UDP, HTTP, Websocket
-    type: REST
+    # Allowed values: GraphQL, gRPC, TCP, UDP, HTTP, Websocket
+    type: HTTP
     # +optional The path to the schema definition file
-    # This is applicable to REST, GraphQL, and gRPC endpoint types
+    # This is applicable to HTTP, GraphQL, and gRPC endpoint types
     # The path should be relative to the workload.yaml file location
     schemaFile: openapi.yaml

--- a/service-go-reading-list/workload.yaml
+++ b/service-go-reading-list/workload.yaml
@@ -21,9 +21,9 @@ endpoints:
     # +required Numeric port value that gets exposed via the endpoint
     port: 8080
     # +required Type of traffic that the endpoint is accepting
-    # Allowed values: REST, GraphQL, gRPC, TCP, UDP, HTTP, Websocket
-    type: REST
+    # Allowed values: GraphQL, gRPC, TCP, UDP, HTTP, Websocket
+    type: HTTP
     # +optional The path to the schema definition file
-    # This is applicable to REST, GraphQL, and gRPC endpoint types
+    # This is applicable to HTTP, GraphQL, and gRPC endpoint types
     # The path should be relative to the workload.yaml file location
     schemaFile: docs/openapi.yaml

--- a/service-python-reading-list/workload.yaml
+++ b/service-python-reading-list/workload.yaml
@@ -21,9 +21,9 @@ endpoints:
     # +required Numeric port value that gets exposed via the endpoint
     port: 5000
     # +required Type of traffic that the endpoint is accepting
-    # Allowed values: REST, GraphQL, gRPC, TCP, UDP, HTTP, Websocket
-    type: REST
+    # Allowed values: GraphQL, gRPC, TCP, UDP, HTTP, Websocket
+    type: HTTP
     # +optional The path to the schema definition file
-    # This is applicable to REST, GraphQL, and gRPC endpoint types
+    # This is applicable to HTTP, GraphQL, and gRPC endpoint types
     # The path should be relative to the workload.yaml file location
     schemaFile: openapi.yaml

--- a/webapp-go-poll-app/workload.yaml
+++ b/webapp-go-poll-app/workload.yaml
@@ -21,5 +21,5 @@ endpoints:
     # +required Numeric port value that gets exposed via the endpoint
     port: 8080
     # +required Type of traffic that the endpoint is accepting
-    # Allowed values: REST, GraphQL, gRPC, TCP, UDP, HTTP, Websocket
+    # Allowed values: GraphQL, gRPC, TCP, UDP, HTTP, Websocket
     type: HTTP

--- a/webapp-php-task-manager/workload.yaml
+++ b/webapp-php-task-manager/workload.yaml
@@ -21,5 +21,5 @@ endpoints:
     # +required Numeric port value that gets exposed via the endpoint
     port: 8080
     # +required Type of traffic that the endpoint is accepting
-    # Allowed values: REST, GraphQL, gRPC, TCP, UDP, HTTP, Websocket
+    # Allowed values: GraphQL, gRPC, TCP, UDP, HTTP, Websocket
     type: HTTP

--- a/webapp-python-flask/workload.yaml
+++ b/webapp-python-flask/workload.yaml
@@ -21,5 +21,5 @@ endpoints:
     # +required Numeric port value that gets exposed via the endpoint
     port: 80
     # +required Type of traffic that the endpoint is accepting
-    # Allowed values: REST, GraphQL, gRPC, TCP, UDP, HTTP, Websocket
+    # Allowed values: GraphQL, gRPC, TCP, UDP, HTTP, Websocket
     type: HTTP

--- a/webapp-react-nginx/workload.yaml
+++ b/webapp-react-nginx/workload.yaml
@@ -21,5 +21,5 @@ endpoints:
     # +required Numeric port value that gets exposed via the endpoint
     port: 80
     # +required Type of traffic that the endpoint is accepting
-    # Allowed values: REST, GraphQL, gRPC, TCP, UDP, HTTP, Websocket
+    # Allowed values: GraphQL, gRPC, TCP, UDP, HTTP, Websocket
     type: HTTP


### PR DESCRIPTION
## Purpose
This PR updates the `workload.yaml` of sample components to use the endpoint type `HTTP` instead of `REST`.

## Related Issues
https://github.com/openchoreo/openchoreo/issues/2787

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated endpoint configuration across multiple services to standardize on HTTP protocol handling
  * Refreshed documentation to reflect updated endpoint type specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->