### PR TITLE
feat: add reading-notes-mcp sample

### DIFF
--- a/service-go-reading-notes-mcp/.gitignore
+++ b/service-go-reading-notes-mcp/.gitignore
@@ -1,0 +1,2 @@
+reading-notes-mcp
+*.exe

--- a/service-go-reading-notes-mcp/Dockerfile
+++ b/service-go-reading-notes-mcp/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o reading-notes-mcp .
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /app/reading-notes-mcp /reading-notes-mcp
+USER nonroot:nonroot
+ENTRYPOINT ["/reading-notes-mcp"]

--- a/service-go-reading-notes-mcp/README.md
+++ b/service-go-reading-notes-mcp/README.md
@@ -1,0 +1,68 @@
+# Reading Notes MCP Server
+
+A native MCP (Model Context Protocol) server that provides reading note management tools. Designed to demonstrate MCP server federation with the `ai-mcp-federation` ClusterTrait on OpenChoreo.
+
+## How It Works
+
+The server implements the MCP protocol (JSON-RPC 2.0 over Streamable HTTP) and exposes three tools for managing reading notes. When registered as an `mcpTarget` in the `ai-mcp-federation` trait, Agent Gateway federates these tools behind a single `MCP_GATEWAY_URL` endpoint.
+
+## MCP Tools
+
+| Tool           | Description                                       |
+|----------------|---------------------------------------------------|
+| `add_note`     | Add a reading note for a book (title + text)      |
+| `list_notes`   | List all notes, optionally filtered by book title |
+| `search_notes` | Search notes by keyword across titles and text    |
+
+## Deploy in OpenChoreo
+
+### 1. Create a Component
+- Set up OpenChoreo following the instructions at https://openchoreo.dev
+- Open the Backstage UI and navigate to **Create**
+- Select **Component Type: Service**
+
+### 2. Build and Deploy
+- Once the build completes, go to the **Deploy** tab
+- Click **Deploy** to deploy the service
+
+## Local Development
+
+### Prerequisites
+
+- Go 1.24 or later
+
+### Run Locally
+
+```bash
+go run . --port 8081
+```
+
+### Test Locally
+
+```bash
+# Initialize MCP session
+curl -X POST http://localhost:8081/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}},"id":1}'
+
+# List available tools
+curl -X POST http://localhost:8081/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/list","id":2}'
+
+# Add a note
+curl -X POST http://localhost:8081/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"add_note","arguments":{"book_title":"Dune","text":"Incredible worldbuilding"}},"id":3}'
+```
+
+## Project Structure
+
+```text
+service-go-reading-notes-mcp/
+├── main.go              # MCP server implementation
+├── go.mod               # Go module definition
+├── Dockerfile           # Container build configuration
+├── workload.yaml        # OpenChoreo workload descriptor
+└── README.md            # This file
+```

--- a/service-go-reading-notes-mcp/go.mod
+++ b/service-go-reading-notes-mcp/go.mod
@@ -1,0 +1,3 @@
+module github.com/openchoreo/sample-workloads/service-go-reading-notes-mcp
+
+go 1.24.2

--- a/service-go-reading-notes-mcp/main.go
+++ b/service-go-reading-notes-mcp/main.go
@@ -1,0 +1,312 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+// --- JSON-RPC 2.0 types ---
+
+type jsonrpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	ID      any             `json:"id,omitempty"`
+}
+
+type jsonrpcResponse struct {
+	JSONRPC string    `json:"jsonrpc"`
+	Result  any       `json:"result,omitempty"`
+	Error   *rpcError `json:"error,omitempty"`
+	ID      any       `json:"id"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// --- MCP protocol types ---
+
+type mcpTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	InputSchema map[string]any `json:"inputSchema"`
+}
+
+type toolCallParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments"`
+}
+
+type toolResult struct {
+	Content []contentBlock `json:"content"`
+	IsError bool           `json:"isError,omitempty"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// --- Note model ---
+
+type Note struct {
+	ID        int    `json:"id"`
+	BookTitle string `json:"book_title"`
+	Text      string `json:"text"`
+}
+
+// --- MCP Server ---
+
+type MCPServer struct {
+	mu     sync.RWMutex
+	notes  []Note
+	nextID int
+	logger *slog.Logger
+}
+
+var tools = []mcpTool{
+	{
+		Name:        "add_note",
+		Description: "Add a reading note for a book. Use this to save thoughts, quotes, or observations about a book.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"book_title": map[string]any{
+					"type":        "string",
+					"description": "Title of the book this note is about",
+				},
+				"text": map[string]any{
+					"type":        "string",
+					"description": "The note content",
+				},
+			},
+			"required": []string{"book_title", "text"},
+		},
+	},
+	{
+		Name:        "list_notes",
+		Description: "List all reading notes, optionally filtered by book title.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"book_title": map[string]any{
+					"type":        "string",
+					"description": "Filter notes by book title (optional, case-insensitive partial match)",
+				},
+			},
+		},
+	},
+	{
+		Name:        "search_notes",
+		Description: "Search reading notes by keyword. Searches in both book titles and note text.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{
+					"type":        "string",
+					"description": "Search keyword",
+				},
+			},
+			"required": []string{"query"},
+		},
+	},
+}
+
+func main() {
+	port := flag.Int("port", 8081, "HTTP server port")
+	flag.Parse()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	server := &MCPServer{logger: logger}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /mcp", server.handleMCP)
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
+
+	addr := fmt.Sprintf(":%d", *port)
+	logger.Info("starting reading-notes MCP server", "addr", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
+		logger.Error("server failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func (s *MCPServer) handleMCP(w http.ResponseWriter, r *http.Request) {
+	var req jsonrpcRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, jsonrpcResponse{
+			JSONRPC: "2.0",
+			Error:   &rpcError{Code: -32700, Message: "parse error"},
+		})
+		return
+	}
+
+	s.logger.Info("mcp request", "method", req.Method)
+
+	switch req.Method {
+	case "initialize":
+		writeJSON(w, jsonrpcResponse{
+			JSONRPC: "2.0",
+			Result: map[string]any{
+				"protocolVersion": "2025-03-26",
+				"capabilities": map[string]any{
+					"tools": map[string]any{},
+				},
+				"serverInfo": map[string]any{
+					"name":    "reading-notes",
+					"version": "1.0.0",
+				},
+			},
+			ID: req.ID,
+		})
+
+	case "notifications/initialized":
+		w.WriteHeader(http.StatusAccepted)
+
+	case "tools/list":
+		writeJSON(w, jsonrpcResponse{
+			JSONRPC: "2.0",
+			Result:  map[string]any{"tools": tools},
+			ID:      req.ID,
+		})
+
+	case "tools/call":
+		result := s.handleToolCall(req.Params)
+		writeJSON(w, jsonrpcResponse{
+			JSONRPC: "2.0",
+			Result:  result,
+			ID:      req.ID,
+		})
+
+	default:
+		writeJSON(w, jsonrpcResponse{
+			JSONRPC: "2.0",
+			Error:   &rpcError{Code: -32601, Message: "method not found: " + req.Method},
+			ID:      req.ID,
+		})
+	}
+}
+
+func (s *MCPServer) handleToolCall(params json.RawMessage) toolResult {
+	var tc toolCallParams
+	if err := json.Unmarshal(params, &tc); err != nil {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "invalid tool call params: " + err.Error()}},
+			IsError: true,
+		}
+	}
+
+	switch tc.Name {
+	case "add_note":
+		return s.addNote(tc.Arguments)
+	case "list_notes":
+		return s.listNotes(tc.Arguments)
+	case "search_notes":
+		return s.searchNotes(tc.Arguments)
+	default:
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "unknown tool: " + tc.Name}},
+			IsError: true,
+		}
+	}
+}
+
+func (s *MCPServer) addNote(args map[string]any) toolResult {
+	bookTitle, _ := args["book_title"].(string)
+	text, _ := args["text"].(string)
+
+	if bookTitle == "" || text == "" {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "book_title and text are required"}},
+			IsError: true,
+		}
+	}
+
+	s.mu.Lock()
+	s.nextID++
+	note := Note{ID: s.nextID, BookTitle: bookTitle, Text: text}
+	s.notes = append(s.notes, note)
+	s.mu.Unlock()
+
+	data, _ := json.Marshal(note)
+	return toolResult{
+		Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("Note added: %s", string(data))}},
+	}
+}
+
+func (s *MCPServer) listNotes(args map[string]any) toolResult {
+	bookTitle, _ := args["book_title"].(string)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var filtered []Note
+	for _, n := range s.notes {
+		if bookTitle == "" || strings.Contains(strings.ToLower(n.BookTitle), strings.ToLower(bookTitle)) {
+			filtered = append(filtered, n)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "No notes found."}},
+		}
+	}
+
+	data, _ := json.MarshalIndent(filtered, "", "  ")
+	return toolResult{
+		Content: []contentBlock{{Type: "text", Text: string(data)}},
+	}
+}
+
+func (s *MCPServer) searchNotes(args map[string]any) toolResult {
+	query, _ := args["query"].(string)
+	if query == "" {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: "query is required"}},
+			IsError: true,
+		}
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	q := strings.ToLower(query)
+	var matches []Note
+	for _, n := range s.notes {
+		if strings.Contains(strings.ToLower(n.BookTitle), q) ||
+			strings.Contains(strings.ToLower(n.Text), q) {
+			matches = append(matches, n)
+		}
+	}
+
+	if len(matches) == 0 {
+		return toolResult{
+			Content: []contentBlock{{Type: "text", Text: fmt.Sprintf("No notes matching '%s'.", query)}},
+		}
+	}
+
+	data, _ := json.MarshalIndent(matches, "", "  ")
+	return toolResult{
+		Content: []contentBlock{{Type: "text", Text: string(data)}},
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}

--- a/service-go-reading-notes-mcp/workload.yaml
+++ b/service-go-reading-notes-mcp/workload.yaml
@@ -1,0 +1,12 @@
+# OpenChoreo Workload Descriptor
+apiVersion: openchoreo.dev/v1alpha1
+
+metadata:
+  name: reading-notes-mcp
+
+endpoints:
+  - name: mcp
+    visibility:
+      - external
+    port: 8081
+    type: HTTP


### PR DESCRIPTION
## Summary
- Add `service-go-reading-notes-mcp` — a native MCP server (Streamable HTTP) that provides reading note management tools
- Exposes 3 tools via MCP protocol: `add_note`, `list_notes`, `search_notes`
- Implements JSON-RPC 2.0 over Streamable HTTP with in-memory note storage

## What's included
- `main.go` — MCP server with tool definitions and handlers
- `Dockerfile` — Multi-stage build with distroless base image
- `workload.yaml` — OpenChoreo workload descriptor
- `README.md` — Usage, MCP tool docs, and local development instructions

## Related Issue
https://github.com/openchoreo/openchoreo/issues/3248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Reading Notes service exposing tools to add notes, list notes (optional book-title filter), and search notes by keyword via JSON-RPC over HTTP (default port 8081); includes a /healthz endpoint.

* **Documentation**
  * Added README with usage, example requests, and local development steps.

* **Chores**
  * Containerization and deployment manifest added; updated ignore rules for build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->