### PR TITLE
feat: add ai-chat-service sample for demonstrating LLM routing

### DIFF
--- a/service-go-ai-chat/Dockerfile
+++ b/service-go-ai-chat/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o ai-chat-service .
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /app/ai-chat-service /ai-chat-service
+USER nonroot:nonroot
+ENTRYPOINT ["/ai-chat-service"]

--- a/service-go-ai-chat/README.md
+++ b/service-go-ai-chat/README.md
@@ -1,0 +1,105 @@
+# AI Chat Service
+
+A Go service that proxies chat requests to any OpenAI-compatible LLM API. Designed to demonstrate the `ai-llm-routing` ClusterTrait on OpenChoreo, which routes LLM traffic through Agent Gateway.
+
+## How It Works
+
+The service exposes a simple `POST /chat` endpoint. It forwards messages to an LLM provider using the OpenAI chat completions API format. When deployed with the `ai-llm-routing` trait, the `OPENAI_BASE_URL` is automatically injected, pointing to Agent Gateway which handles provider routing, API key management, rate limiting, and PII guardrails.
+
+## Deploy in OpenChoreo
+
+Follow these steps to deploy the application in OpenChoreo:
+
+### 1. Create a Component
+- Set up OpenChoreo following the instructions at https://openchoreo.dev
+- Open the Backstage UI and navigate to **Create**
+- Select **Component Type: Service**
+- After creation, navigate to the **Workflows** tab to view builds
+
+### 2. Build and Deploy
+- Once the build completes successfully, go to the **Deploy** tab
+- Click **Deploy** to deploy the service to your environment
+
+### 3. Test the Service
+Navigate to the **Test** section in the left menu to test the service endpoints.
+
+## API Endpoints
+
+### POST /chat
+
+Send a message and get an AI-generated reply.
+
+**Request:**
+```bash
+curl -X POST http://localhost:8080/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message": "What is Kubernetes?"}'
+```
+
+**Response:**
+```json
+{
+  "reply": "Kubernetes is an open-source container orchestration platform...",
+  "model": "gpt-4o-mini",
+  "usage": {
+    "prompt_tokens": 25,
+    "completion_tokens": 42,
+    "total_tokens": 67
+  }
+}
+```
+
+You can optionally specify a model in the request to switch providers on the fly:
+```bash
+curl -X POST http://localhost:8080/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hello", "model": "llama-3.3-70b-versatile"}'
+```
+
+### GET /healthz, GET /readyz
+
+Health and readiness probes.
+
+## Configuration
+
+| Environment Variable | Required | Default | Description |
+|---------------------|----------|---------|-------------|
+| `OPENAI_API_KEY` | No | - | API key (not needed when using `ai-llm-routing` trait) |
+| `OPENAI_BASE_URL` | No | `https://api.openai.com` | Base URL (injected by `ai-llm-routing` trait) |
+| `OPENAI_MODEL` | No | `gpt-4o-mini` | Default model to use |
+| `SYSTEM_PROMPT` | No | Generic helpful assistant | System prompt for the conversation |
+| `LOG_LEVEL` | No | `info` | Log level (debug, info, warn, error) |
+| `X_OPENCHOREO_COMPONENT` | No | - | Component identity header (injected by trait) |
+
+## Project Structure
+
+```
+service-go-ai-chat/
+├── main.go              # Main service implementation
+├── go.mod               # Go module definition
+├── Dockerfile           # Container build configuration
+├── workload.yaml        # OpenChoreo workload descriptor
+└── README.md            # This file
+```
+
+## Local Development
+
+### Prerequisites
+
+- Go 1.24 or later
+- An OpenAI API key (or compatible provider)
+
+### Run Locally
+
+```bash
+export OPENAI_API_KEY="sk-..."
+go run . --port 8080
+```
+
+### Test Locally
+
+```bash
+curl -X POST http://localhost:8080/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hello, what can you do?"}'
+```

--- a/service-go-ai-chat/go.mod
+++ b/service-go-ai-chat/go.mod
@@ -1,0 +1,3 @@
+module github.com/openchoreo/sample-workloads/service-go-ai-chat
+
+go 1.24.2

--- a/service-go-ai-chat/main.go
+++ b/service-go-ai-chat/main.go
@@ -1,0 +1,278 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// ChatRequest is the incoming request from the client.
+type ChatRequest struct {
+	Message string `json:"message"`
+	Model   string `json:"model,omitempty"`
+}
+
+// ChatResponse is the reply sent back to the client.
+type ChatResponse struct {
+	Reply string `json:"reply"`
+	Model string `json:"model"`
+	Usage *Usage `json:"usage,omitempty"`
+}
+
+// Usage contains token usage information from the OpenAI API.
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// ErrorResponse is returned on errors.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// OpenAI API wire types
+
+type openAIRequest struct {
+	Model    string          `json:"model"`
+	Messages []openAIMessage `json:"messages"`
+}
+
+type openAIMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIResponse struct {
+	Choices []struct {
+		Message openAIMessage `json:"message"`
+	} `json:"choices"`
+	Model string `json:"model"`
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// Server holds the service dependencies.
+type Server struct {
+	openAIKey     string
+	openAIBaseURL string
+	model         string
+	systemPrompt  string
+	httpClient    *http.Client
+	logger        *slog.Logger
+}
+
+func main() {
+	port := flag.Int("port", 8080, "HTTP server port")
+	flag.Parse()
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: parseLogLevel(os.Getenv("LOG_LEVEL")),
+	}))
+
+	openAIKey := os.Getenv("OPENAI_API_KEY")
+	if openAIKey == "" {
+		logger.Warn("OPENAI_API_KEY not set, assuming auth is handled by an AI gateway")
+	}
+
+	baseURL := os.Getenv("OPENAI_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://api.openai.com"
+	}
+
+	model := os.Getenv("OPENAI_MODEL")
+	if model == "" {
+		model = "gpt-4o-mini"
+	}
+
+	systemPrompt := os.Getenv("SYSTEM_PROMPT")
+	if systemPrompt == "" {
+		systemPrompt = "You are a helpful assistant. Provide concise and accurate answers."
+	}
+
+	srv := &Server{
+		openAIKey:     openAIKey,
+		openAIBaseURL: strings.TrimRight(baseURL, "/"),
+		model:         model,
+		systemPrompt:  systemPrompt,
+		httpClient:    &http.Client{Timeout: 30 * time.Second},
+		logger:        logger,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", srv.handleHealth)
+	mux.HandleFunc("GET /readyz", srv.handleReady)
+	mux.HandleFunc("POST /chat", srv.handleChat)
+
+	addr := fmt.Sprintf(":%d", *port)
+	httpServer := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		logger.Info("starting server", "addr", addr, "model", model, "openai_base_url", baseURL)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("server failed", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	logger.Info("shutting down server")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		logger.Error("shutdown failed", "error", err)
+	}
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, "ok")
+}
+
+func (s *Server) handleReady(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, "ready")
+}
+
+func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
+	var req ChatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if strings.TrimSpace(req.Message) == "" {
+		s.writeError(w, http.StatusBadRequest, "message is required")
+		return
+	}
+
+	model := s.model
+	if req.Model != "" {
+		model = req.Model
+	}
+
+	s.logger.Info("chat request received", "message_length", len(req.Message), "model", model)
+
+	reply, err := s.callOpenAI(r.Context(), req.Message, model)
+	if err != nil {
+		s.logger.Error("openai call failed", "error", err)
+		s.writeError(w, http.StatusBadGateway, "failed to get response from AI provider")
+		return
+	}
+
+	s.logger.Info("chat response sent", "model", reply.Model, "total_tokens", reply.Usage.TotalTokens)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reply)
+}
+
+func (s *Server) callOpenAI(ctx context.Context, message string, model string) (*ChatResponse, error) {
+	reqBody := openAIRequest{
+		Model: model,
+		Messages: []openAIMessage{
+			{Role: "system", Content: s.systemPrompt},
+			{Role: "user", Content: message},
+		},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := s.openAIBaseURL + "/v1/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if s.openAIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+s.openAIKey)
+	}
+	// Send component identity header for agentgateway routing
+	if component := os.Getenv("X_OPENCHOREO_COMPONENT"); component != "" {
+		httpReq.Header.Set("x-openchoreo-component", component)
+	}
+
+	resp, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("openai returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var openAIResp openAIResponse
+	if err := json.Unmarshal(respBody, &openAIResp); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	if len(openAIResp.Choices) == 0 {
+		return nil, fmt.Errorf("no choices in response")
+	}
+
+	result := &ChatResponse{
+		Reply: openAIResp.Choices[0].Message.Content,
+		Model: openAIResp.Model,
+	}
+	if openAIResp.Usage != nil {
+		result.Usage = &Usage{
+			PromptTokens:     openAIResp.Usage.PromptTokens,
+			CompletionTokens: openAIResp.Usage.CompletionTokens,
+			TotalTokens:      openAIResp.Usage.TotalTokens,
+		}
+	}
+
+	return result, nil
+}
+
+func (s *Server) writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(ErrorResponse{Error: msg})
+}
+
+func parseLogLevel(level string) slog.Level {
+	switch strings.ToLower(level) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/service-go-ai-chat/workload.yaml
+++ b/service-go-ai-chat/workload.yaml
@@ -1,0 +1,25 @@
+# OpenChoreo Workload Descriptor
+# This file defines how your workload exposes endpoints and connects to other services.
+# It sits alongside your source code and gets converted to a Workload Custom Resource (CR).
+apiVersion: openchoreo.dev/v1alpha1
+
+# Basic metadata for the workload
+metadata:
+  # +required Name of the workload
+  name: ai-chat-service
+
+# +optional Incoming connection details for the component
+# Endpoints define the network interfaces that this workload exposes to other services
+endpoints:
+  - # +required Unique name for the endpoint
+    # This name will be used when generating the managed API and as the key in the CR map
+    name: chat-api
+    # +optional Visibility of the endpoint
+    # Allowed values: project, namespace, internal, external
+    visibility:
+      - external
+    # +required Numeric port value that gets exposed via the endpoint
+    port: 8080
+    # +required Type of traffic that the endpoint is accepting
+    # Allowed values: GraphQL, gRPC, TCP, UDP, HTTP, Websocket
+    type: HTTP


### PR DESCRIPTION
## Purpose
- Add `service-go-ai-chat` sample — a Go service that proxies chat requests to any OpenAI-compatible LLM API
- Designed to demonstrate the `ai-llm-routing` ClusterTrait, which routes LLM traffic through Agent Gateway with provider switching, rate limiting, and PII guardrails
- Follows the existing `service-<language>-<name>` naming convention

## What's included
- `main.go` — HTTP service with `POST /chat` endpoint, forwards to OpenAI-compatible API
- `Dockerfile` — Multi-stage build with distroless base image
- `workload.yaml` — OpenChoreo workload descriptor
- `README.md` — Usage, API docs, and local development instructions

## Related Issues
https://github.com/openchoreo/openchoreo/issues/3248

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
