### PR TITLE
fix: update nginx WebSocket route and add multi-arch Go build support

### DIFF
--- a/project-doclet-app/service-go-collab/Dockerfile
+++ b/project-doclet-app/service-go-collab/Dockerfile
@@ -1,12 +1,16 @@
-FROM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /out/collab ./cmd
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/collab ./cmd
 
 FROM alpine:3.19
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 WORKDIR /app
 COPY --from=builder /out/collab /app/collab
 EXPOSE 8090
+USER appuser
 CMD ["/app/collab"]

--- a/project-doclet-app/service-go-document/Dockerfile
+++ b/project-doclet-app/service-go-document/Dockerfile
@@ -1,12 +1,16 @@
-FROM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /out/document ./cmd
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/document ./cmd
 
 FROM alpine:3.19
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 WORKDIR /app
 COPY --from=builder /out/document /app/document
 EXPOSE 8080
+USER appuser
 CMD ["/app/document"]

--- a/project-doclet-app/webapp-react-frontend/nginx.conf.template
+++ b/project-doclet-app/webapp-react-frontend/nginx.conf.template
@@ -14,7 +14,7 @@ server {
   }
 
   location ^~ /ws/collab-svc {
-    proxy_pass ${COLLAB_SERVICE_URL}/;
+    proxy_pass ${COLLAB_SERVICE_URL}/ws;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
## Description

Two doclet fixes that were baked into ghcr images but never committed to source.

## Changes

- `project-doclet-app/webapp-react-frontend/nginx.conf.template`: `proxy_pass` `/` → `/ws` so WebSocket upgrades reach the collab service route.
- `project-doclet-app/service-go-document/Dockerfile`: Multi-arch build support (`--platform=$BUILDPLATFORM`, `ARG TARGETOS`/`ARG TARGETARCH`, `GOOS=$TARGETOS GOARCH=$TARGETARCH`) and non-root `USER`.
- `project-doclet-app/service-go-collab/Dockerfile`: Same multi-arch and non-root fixes.

## Testing

Both Dockerfiles build successfully with `docker build --build-arg TARGETOS=linux --build-arg TARGETARCH=amd64`. `docker buildx build --platform linux/amd64,linux/arm64` should also succeed for both Go services (cross-compilation avoids QEMU).

## Related Issues

Fixes openchoreo/openchoreo#4029